### PR TITLE
🐛 Allow single region runs + Some Bugfixes

### DIFF
--- a/epiCata/R/preprocessing.R
+++ b/epiCata/R/preprocessing.R
@@ -70,14 +70,19 @@ prepare_stan_data <- function(covid_data, interventions, onset_to_death, IFR,
   x1 <- EnvStats::rgammaAlt(1e6, infection_to_onset$avg_days, infection_to_onset$coeff_variation) # infection-to-onset distribution
   x2 <- EnvStats::rgammaAlt(1e6, onset_to_death$avg_days, onset_to_death$coeff_variation) # onset-to-death distribution
   ecdf.saved <- ecdf(x1 + x2)
-
-  # Add a padding to the serial interval if it doesn't contain enough rows
-  padded_serial_interval <- get_padded_serial_interval(serial_interval, N2)
+  
+  gen_serial_interval <- ecdf(EnvStats::rgammaAlt(1e6, 6.5, 0.62)) # serial-interval distribution
+  SI <- rep(0, N2) # f is the probability of dying on day i given infection
+  SI[1] <- (gen_serial_interval(1.5) - gen_serial_interval(0))
+  for (i in 2:N2) {
+    SI[i] <- (gen_serial_interval(i + .5) - gen_serial_interval(i - .5))
+  }
 
   #### INTERVENTIONS ####
 
   # A join with all_dates_df will ensure that all dates are represented
-  all_dates <- seq(min(covid_data$data_ocorrencia), max(covid_data$data_ocorrencia), by = ifelse(is_weekly, "1 week", "1 day"))
+  all_dates <- seq(min(covid_data$data_ocorrencia), max(covid_data$data_ocorrencia), 
+                   by = ifelse(is_weekly, "1 week", "1 day"))
   all_dates_df <- expand.grid(sort(unique(interventions$AREA)), all_dates)
   colnames(all_dates_df) <- c("AREA", "DATA")
   common_interventions <- interventions %>%
@@ -95,10 +100,9 @@ prepare_stan_data <- function(covid_data, interventions, onset_to_death, IFR,
   reported_cases <- list()
   deaths_by_location <- list()
   stan_data <- list(
-    M = length(available_locations), N = NULL, deaths = NULL, f = NULL, N0 = ifelse(is_weekly, 1, 6), # N0 = 6 to make it consistent with Rayleigh
-    cases = NULL, SI = padded_serial_interval$fit[1:N2], features = NULL,
-    EpidemicStart = NULL, pop = NULL,
-    N2 = N2, x = 1:N2, P = n_covariates
+    M = length(available_locations), N = NULL, deaths = NULL, f = NULL, N0 = ifelse(is_weekly, 3, 6), # N0 = 6 to make it consistent with Rayleigh
+    cases = NULL, SI = SI, features = NULL,
+    pop = NULL, N2 = N2, x = 1:N2, P = n_covariates
   )
 
   # Covariates array
@@ -126,7 +130,6 @@ prepare_stan_data <- function(covid_data, interventions, onset_to_death, IFR,
     reported_cases[[location_name]] <- result_list$reported_cases
     deaths_by_location[[location_name]] <- result_list$deaths_by_location
 
-    stan_data$EpidemicStart <- c(stan_data$EpidemicStart, result_list$epidemic_start)
     stan_data$pop <- c(stan_data$pop, result_list$location_pop)
     stan_data$N <- c(stan_data$N, result_list$N)
     stan_data$f <- cbind(stan_data$f, result_list$f)
@@ -144,12 +147,10 @@ prepare_stan_data <- function(covid_data, interventions, onset_to_death, IFR,
     cat(sprintf("  > %s - %s\n", min(result_list$dates), max(result_list$dates)))
   }
 
-  if (length(stan_data$EpidemicStart) == 1) {
-    stop("Model does not support only one region")
-    # FIXME: Bug with single location, the fix below does not work
-    dim(stan_data$EpidemicStart) <- 1
+  if(typeof(stan_data$pop) == "integer"){
+    stan_data$pop <- as.array(stan_data$pop)
   }
-
+  
   return(list(
     "stan_data" = stan_data,
     "dates" = dates,
@@ -161,7 +162,9 @@ prepare_stan_data <- function(covid_data, interventions, onset_to_death, IFR,
   ))
 }
 
-get_stan_data_for_location <- function(location_name, population, IFR, N2, ecdf.saved, covid_data, common_interventions, is_weekly = FALSE, mobility, google_mobility_window_size, pop_df) {
+get_stan_data_for_location <- function(location_name, population, IFR, N2, ecdf.saved, 
+                                       covid_data, common_interventions, is_weekly = FALSE, mobility, 
+                                       google_mobility_window_size, pop_df) {
 
   #### FILTER RELEVANT INFORMATION ####
   cat(sprintf("\n\nParsing data for location: %s\n", location_name))
@@ -187,7 +190,6 @@ get_stan_data_for_location <- function(location_name, population, IFR, N2, ecdf.
   location_data <- location_data[month_before_deaths_mark:nrow(location_data), ]
 
   #### EPIDEMIC START AND POPULATION ####
-  epidemic_start <- idx_deaths_mark + 1 - month_before_deaths_mark
   location_pop <- population[population$location_name == location_name, ]$pop
 
   #### N and N2 ####
@@ -250,7 +252,7 @@ get_stan_data_for_location <- function(location_name, population, IFR, N2, ecdf.
   cases <- c(as.vector(as.numeric(location_data$casos)), rep(-1, location_forecast))
 
   return(list(
-    epidemic_start = epidemic_start, location_pop = location_pop, N = N, N2 = N2, f = f,
+    location_pop = location_pop, N = N, N2 = N2, f = f,
     deaths = deaths, cases = cases, x = 1:N2,
     location_covariates = location_covariates,
     dates = location_data$data_ocorrencia,

--- a/epiCata/R/utils.R
+++ b/epiCata/R/utils.R
@@ -216,6 +216,10 @@ get_ranges_counting_missing_data <- function(model_output, forecast) {
   rr$min_missing_date <- min(as_date(model_output$covid_data$data_ocorrencia))
   rr$min_date <- min(reduce(model_output$stan_list$dates, min))
   rr$max_date <- reduce(model_output$stan_list$dates, max)
+  if(length(model_output$stan_list$available_locations) == 1){
+    rr$max_date <- max(rr$max_date) 
+  }
+
   rr$max_forecast_date <- rr$max_date + rr$forecast
   if (rr$is_weekly) {
     rr$min_missing_date <- ymd(cut(rr$min_missing_date, "week", start.on.monday = TRUE))
@@ -470,7 +474,7 @@ get_merged_forecast_dfs_on_model_data <- function(location_names, model_output, 
     # (UNUSED) Unweighted
     # rt_samples[,agg_idx] <- rt_samples[,agg_idx] + model_output$out$Rt[,loc_idx,i]
     # Weighted by pop
-    rt_samples[, agg_idx] <- rt_samples[, agg_idx] + model_output$out$Rt[, loc_idx, i] * model_output$stan_list$stan_data$pop[i]
+    rt_samples[, agg_idx] <- rt_samples[, agg_idx] + model_output$out$Rt_adj[, loc_idx, i] * model_output$stan_list$stan_data$pop[i]
 
     # (UNUSED) Unweighted
     # rt_samples_n[,agg_idx] <- rt_samples_n[,agg_idx] + 1

--- a/epiCata/R/utils.R
+++ b/epiCata/R/utils.R
@@ -101,6 +101,7 @@ make_option_list <- function(default_locations,
                              serial_interval_csv = "serial_interval.csv",
                              save_path = "../",
                              model_init_filename = NULL,
+                             mode="DEBUG",
                              is_weekly = FALSE) {
   if (is.null(reference_date)) {
     require(lubridate)

--- a/epiCata/inst/extdata/stan-models/base.stan
+++ b/epiCata/inst/extdata/stan-models/base.stan
@@ -8,7 +8,6 @@ data {
   int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
   matrix[N2, M] f; // h * s
   matrix[N2, P] X[M]; // features matrix
-  int EpidemicStart[M];
   real pop[M];
   real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
 }
@@ -76,7 +75,7 @@ transformed parameters {
 model {
   tau ~ exponential(0.03);
   for (m in 1:M){
-      y[m] ~ exponential(1/tau);
+      y[m] ~ exponential(1/tau); # The initial seed
   }
   gamma ~ normal(0,.2);
   phi ~ normal(0,5);
@@ -87,7 +86,7 @@ model {
     alpha1[i,] ~ normal(0,gamma);
   ifr_noise ~ normal(1,0.1);
   for(m in 1:M){
-    deaths[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(E_deaths[EpidemicStart[m]:N[m], m], phi);
+    deaths[1:N[m], m] ~ neg_binomial_2(E_deaths[1:N[m], m], phi);
    }
 }
 

--- a/epiCataPlot/R/plot.R
+++ b/epiCataPlot/R/plot.R
@@ -161,7 +161,7 @@ plot_graph_A <- function(location_name, x_breaks, dfs, model_is_weekly = FALSE) 
   require(scales)
   require(lubridate)
   model_is_weekly <- ifelse(is.null(model_is_weekly), FALSE, model_is_weekly)
-
+  
   if (model_is_weekly) {
     dfs$data_location$time <- dfs$data_location$time + days(6)
     dfs$data_location_forecast$time <- dfs$data_location_forecast$time + days(6)
@@ -187,6 +187,10 @@ plot_graph_A <- function(location_name, x_breaks, dfs, model_is_weekly = FALSE) 
   data_cases <- rbind(data_cases_95, data_cases_50)
   levels(data_cases$key) <- c("ninetyfive", "fifty")
 
+  # Some initial time points are not modelled on STAN. 
+  # In these cases, we only want to show data, not non-existing stan estimates on the plot
+  data_cases <- data_cases %>% filter(cases_min != 0 & cases_max != 0)
+  
   cases_legend <- data.frame(
     text = c("Confirmados: ", "Estimado (min): ", "Estimado (max): "),
     x = max(x_breaks),
@@ -291,6 +295,10 @@ plot_graph_B <- function(location_name, x_breaks, dfs, is_cumulative = FALSE, mo
   data_deaths <- rbind(data_deaths_95, data_deaths_50)
   levels(data_deaths$key) <- c("ninetyfive", "fifty")
 
+  # Some initial time points are not modelled on STAN. 
+  # In these cases, we only want to show data, not non-existing stan estimates on the plot
+  data_deaths <- data_deaths %>% filter(death_min != 0 & death_max != 0)
+  
   if (is_cumulative) {
     data_deaths <- data_deaths %>%
       filter(key == "fifty") %>%
@@ -383,6 +391,10 @@ plot_graph_C <- function(location_name, x_breaks, dfs, use_stepribbon = FALSE, m
   data_rt <- rbind(data_rt_95, data_rt_50) %>% filter(x_min_date <= time, time <= x_max_date)
   levels(data_rt$key) <- c("ninetyfive", "fifth")
 
+  # Some initial time points are not modelled on STAN. 
+  # In these cases, we only want to show data, not non-existing stan estimates on the plot
+  data_rt <- data_rt %>% filter(rt_min != 0 & rt_max != 0)
+  
   max_rt <- ceiling(max(data_rt$rt_max))
 
   original_y_breaks <- seq(1, ceiling(max_rt))

--- a/run_single_region.R
+++ b/run_single_region.R
@@ -1,0 +1,36 @@
+library(optparse)
+library(epiCataPlot)
+library(epiCata)
+library(lubridate)
+
+default_locations <- c("SC_MAC_GRANDE_FLORIANOPOLIS")
+
+option_list <- make_option_list(default_locations,
+                                mode="FULL",
+                                default_locations_text = "only single-region",
+                                reference_date="2021_06_07",
+                                nickname="")
+
+opt_parser <- OptionParser(option_list=option_list);
+opt <- parse_args(opt_parser);
+
+model_output <- run_model_with_opt(opt,default_locations)
+
+make_all_three_panel_plot(model_output, aggregate_name = opt$aggregate_name, 
+                          save_path = opt$save_path)
+
+mi <- NULL
+wma <- NULL
+ma <- NULL
+
+make_all_forecast_plots(model_output, aggregate_name = opt$aggregate_name, 
+                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma, 
+                        save_path = opt$save_path)
+
+last_8_weeks = ymd(model_output$reference_date_str) - 8*7 - 1
+
+make_all_C_plot(model_output, aggregate_name = opt$aggregate_name, min_x_break=last_8_weeks, save_path = opt$save_path)
+
+#save_data_for_dashboard(model_output, save_path = "~/epiCataDashboard/", aggregate_name = opt$aggregate_name)
+
+print("Done")


### PR DESCRIPTION
# Changes

- Allow a single region to be fitted
- In practice, EpidemicStart was always set 1 because of the way the data was being filtered and preprocessed. So, I adjusted the preprocessing so that the epidemic in each location starts 30 days before the 10-death mark, therefore removing the necessity of the `EpidemicStart` from the STAN model
- Generate the Serial Interval distribution on the code, instead of using the legacy polynomial inherited by the original Flaxman et al model

# How to validate this PR

- Clone this branch
- Rebuild the library. Tip: If you are starting the environment on RStudio, run the command:
```r
setwd("epiCata")
devtools::build()
devtools::install(upgrade="never")
setwd("../")
```
- Run the model for just a single region, say `SC_MAC_GRANDE_FLORIANOPOLIS`