### PR TITLE
🐛Fixes run_single_region.R 

### DIFF
--- a/run_single_region.R
+++ b/run_single_region.R
@@ -3,9 +3,37 @@ library(epiCataPlot)
 library(epiCata)
 library(lubridate)
 
-default_locations <- c("SC_MAC_GRANDE_FLORIANOPOLIS")
 
-option_list <- make_option_list(default_locations,
+macro_health_regions <- c("SC_ESTADO",
+                          "SC_MAC_FOZ_DO_RIO_ITAJAI",
+                          "SC_MAC_PLANALTO_NORTE_E_NORDESTE",
+                          "SC_MAC_GRANDE_OESTE",
+                          "SC_MAC_GRANDE_FLORIANOPOLIS",
+                          "SC_MAC_SUL",
+                          "SC_MAC_ALTO_VALE_DO_ITAJAI",
+                          "SC_MAC_MEIO_OESTE_E_SERRA_CATARINENSE")
+
+micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
+                          "SC_RSA_ALTO_VALE_DO_ITAJAI",
+                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
+                          "SC_RSA_CARBONIFERA",
+                          "SC_RSA_EXTREMO_OESTE",
+                          "SC_RSA_EXTREMO_SUL_CATARINENSE",
+                          "SC_RSA_FOZ_DO_RIO_ITAJAI",
+                          "SC_RSA_GRANDE_FLORIANOPOLIS",
+                          "SC_RSA_LAGUNA",
+                          "SC_RSA_MEDIO_VALE_DO_ITAJAI",
+                          "SC_RSA_MEIO_OESTE",
+                          "SC_RSA_NORDESTE",
+                          "SC_RSA_OESTE",
+                          "SC_RSA_PLANALTO_NORTE",
+                          "SC_RSA_SERRA_CATARINENSE",
+                          "SC_RSA_XANXERE")
+
+all_possible_locations <- c(macro_health_regions, micro_health_regions)
+
+
+option_list <- make_option_list(all_possible_locations,
                                 mode="FULL",
                                 default_locations_text = "only single-region",
                                 reference_date="2021_06_07",
@@ -14,7 +42,9 @@ option_list <- make_option_list(default_locations,
 opt_parser <- OptionParser(option_list=option_list);
 opt <- parse_args(opt_parser);
 
-model_output <- run_model_with_opt(opt,default_locations)
+
+# TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
+model_output <- run_model_with_opt(opt,opt[["allowed_locations"]])
 
 make_all_three_panel_plot(model_output, aggregate_name = opt$aggregate_name, 
                           save_path = opt$save_path)


### PR DESCRIPTION
Script run_single_region.R was taking its name too seriously and only allowed SC-MAC_GRANDE_FLORIANOPOLIS region to be run.

# How to validate

1. Rebuild the package
```console
R -e "setwd(\"epiCata\");devtools::build();devtools::install(upgrade=\"never\");setwd(\"../\")"
```
2. Run some other MAC (macroregions) or RSA (micro-regions)

```console
Rscript run_single_region.R -m DEBUG -r "2020-07-10" -l "SC_RSA_ALTO_URUGUAI_CATARINENSE"
```

Closes #28