### PR TITLE
🐛base-reported was still using old EpidemicStart parameter

### DIFF
--- a/epiCata/inst/extdata/stan-models/base-reported.stan
+++ b/epiCata/inst/extdata/stan-models/base-reported.stan
@@ -8,7 +8,6 @@ data {
   int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
   matrix[N2, M] f; // h * s
   matrix[N2, P] X[M]; // features matrix
-  int EpidemicStart[M];
   real pop[M];
   real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
 }
@@ -104,8 +103,8 @@ model {
   infection_overestimate ~ normal(11.5,2);
   
   for(m in 1:M){
-    cases[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(prediction[EpidemicStart[m]:N[m], m] / infection_overestimate[m], phi);
-    deaths[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(E_deaths[EpidemicStart[m]:N[m], m], phi);
+    cases[1:N[m], m] ~ neg_binomial_2(prediction[1:N[m], m] / infection_overestimate[m], phi);
+    deaths[1:N[m], m] ~ neg_binomial_2(E_deaths[1:N[m], m], phi);
    }
 }
 


### PR DESCRIPTION
Fixes #36 and closes #36

# How to validate

1. Rebuild the package
```r
R -e "setwd(\"epiCata\");devtools::build();devtools::install(upgrade=\"never\");setwd(\"../\")"
```

2. The run_region script should now work fine with model base-reported (configured with parameter `-u`):
```r
Rscript run_single_region.R -u "base-reported" -m DEVELOP -i 2000 
   -w 600 -k 7 -c 4 -t 8 -r "2021-06-28" -v TRUE -l "SC_RSA_FOZ_DO_RIO_ITAJAI" 

```