### PR TITLE
Consider previously trained model for each region

### DIFF
--- a/combine_independent_results.R
+++ b/combine_independent_results.R
@@ -48,51 +48,61 @@ model_files <- list.files(dir_saved_models)
 
 this_dir = getwd()
 
+# update covid_data in model_output_all
+covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
+                                  allowed_locations = micro_health_regions
+)
+
+
+
 setwd(dir_saved_models)
 
 if (length(model_files) != length(micro_health_regions)){
-    print(sprintf("Not enough single-region models! Check if all models concluded successfully. Expected %s, got %s",
-                    length(micro_health_regions), length(model_files)))
-    
+  sprintf("Not enough single-region models! Check if all models concluded successfully. Expected %s, got %s",
+          length(micro_health_regions), length(model_files)    )
+  # HOW DO I PRINT AN ERROR HERE?
+  
 } else {
-    for (model_file in model_files){ 
-        i <- which(model_files==model_file)
-        print(sprint("Loading %s", model_file))
-	load(model_file)
-       
-        if (i==1){
-            model_output_all <- copy(model_output)
-            model_output_all$stan_list$stan_data$M <- length(micro_health_regions)
-        } else {
-            model_output_all <- update_aggregated_model(model_output_all, model_output)
-        }
-        rm(model_output)
+  for (model_file in model_files){
+    i <- which(model_files==model_file)
+    load(model_file)
+    
+    if (i==1){
+      model_output_all <- copy(model_output)
+      model_output_all$stan_list$stan_data$M <- length(micro_health_regions)
+    } else {
+      model_output_all <- update_aggregated_model(model_output_all, model_output)
     }
+    rm(model_output)
+  }
 }
-
-model_output_all_filename <- paste0(model_output_all$filename_suffix, "-HEALTH-REG-INDEPEND-stanfit.Rdata")
-cat(sprintf("\nSaving joint model objects to %s", model_output_all_filename))
-save(model_output_all, file = model_output_all_filename)
-
-
-setwd(this_dir)
-
-# update covid_data in model_output_all
-covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
-                              allowed_locations = micro_health_regions 
-)
 
 model_output_all[["covid_data"]] <- covid_data_all
 
+filename_suffix <- paste0(model_output_all$reference_date_str, "_",
+                          model_output_all$model_name, "_",
+                          model_output_all$mode, "_",
+                          "HEALTH-REG-INDEPEND")
 
-make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name, save_path = opt$save_path)
+model_output_all$filename_suffix <- filename_suffix
+
+model_output_all_filename <- paste0(model_output_all$filename_suffix, "-stanfit.Rdata")
+
+cat(sprintf("\nSaving joint model objects to %s", model_output_all_filename))
+save(model_output_all, file = model_output_all_filename)
+
+setwd(this_dir)
+
+
+make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name,
+                          save_path = opt$save_path)
 
 mi <- NULL
 wma <- NULL
 ma <- NULL
 
-make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name, 
-                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma, 
+make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name,
+                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma,
                         save_path = opt$save_path)
 
 last_8_weeks = ymd(model_output_all$reference_date_str) - 8*7 - 1
@@ -102,6 +112,3 @@ make_all_C_plot(model_output_all, aggregate_name = opt$aggregate_name, min_x_bre
 save_data_for_dashboard(model_output_all, save_path = "~/epiCataDashboard/", aggregate_name = opt$aggregate_name)
 
 print("Done")
-
-
-

--- a/epiCata/R/model.R
+++ b/epiCata/R/model.R
@@ -150,6 +150,26 @@ save_fitted_model <- function(model_output, reference_date, save_path = "./") {
   return(model_output)
 }
 
+save_fitted_model_independent <- function(model_output, reference_date, location_name, save_path = "./") {
+  reference_date_str <- strftime(reference_date, "%Y_%m_%d")
+  
+  # Assign a random number to JOBID
+  JOBID <- as.character(abs(round(rnorm(1) * 1000000)))
+  filename_suffix <- paste0(reference_date_str, "_", location_name, "_", model_output$model_name, "_", model_output$mode, "_", JOBID)
+  
+  dir.create(paste0(save_path, "results/", reference_date_str), recursive = TRUE, showWarnings = FALSE)
+  dir.create(paste0(save_path, "figures/", reference_date_str), recursive = TRUE, showWarnings = FALSE)
+  
+  model_output$reference_date_str <- reference_date_str
+  model_output$filename_suffix <- filename_suffix
+  
+  model_output_filename <- paste0(save_path, "results/", reference_date_str, "/", filename_suffix, "-stanfit.Rdata")
+  cat(sprintf("\nSaving model objects to %s", model_output_filename))
+  save(model_output, file = model_output_filename)
+  
+  return(model_output)
+}
+
 change_model_name <- function(model_output, new_model_name, save_path = "./") {
   reference_date_str <- model_output$reference_date_str
   model_output$model_name <- new_model_name

--- a/epiCata/R/utils.R
+++ b/epiCata/R/utils.R
@@ -200,6 +200,7 @@ make_option_list <- function(default_locations,
                              serial_interval_csv = "serial_interval.csv",
                              save_path = "../",
                              model_init_filename = NULL,
+                             model_init_period_dif = 7,
                              mode="DEBUG",
                              is_weekly = FALSE) {
   if (is.null(reference_date)) {
@@ -296,6 +297,10 @@ make_option_list <- function(default_locations,
     make_option(c("-e", "--model_init_filename"),
       type = "character", default = model_init_filename, dest = "model_init_filename",
       help = sprintf("Model to init from. If NULL it won't be used. If 'True' reads past week model. Default: %s", ifelse(is.null(model_init_filename), "NULL", model_init_filename))
+    ),
+    make_option(c("-j", "--model_init_period_dif"),
+                type = "integer", default = 7, dest = "model_init_period_dif",
+                help = sprintf("Number of days the model to init from is distant from the reference date. Only used if model_init_filename is not NULL. Default: 7")
     ),
     make_option(c("-y", "--is-weekly"),
       type = "logical", default = is_weekly, dest = "is_weekly",

--- a/run_health_regions_A.R
+++ b/run_health_regions_A.R
@@ -26,37 +26,54 @@ micro_health_regions_A <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
 
 
 micro_health_regions_B <- c("SC_RSA_LAGUNA",
-                          "SC_RSA_MEDIO_VALE_DO_ITAJAI",
-                          "SC_RSA_MEIO_OESTE",
-                          "SC_RSA_NORDESTE",
-                          "SC_RSA_OESTE",
-                          "SC_RSA_PLANALTO_NORTE",
-                          "SC_RSA_SERRA_CATARINENSE",
-                          "SC_RSA_XANXERE")
+                            "SC_RSA_MEDIO_VALE_DO_ITAJAI",
+                            "SC_RSA_MEIO_OESTE",
+                            "SC_RSA_NORDESTE",
+                            "SC_RSA_OESTE",
+                            "SC_RSA_PLANALTO_NORTE",
+                            "SC_RSA_SERRA_CATARINENSE",
+                            "SC_RSA_XANXERE")
 
 micro_health_regions <- c(micro_health_regions_A, micro_health_regions_B)
 
-for (location in micro_health_regions_A){ 
-    i <- which(micro_health_regions_A==location)
-    option_list <- make_option_list(location,
-                                    mode="FULL",
-                                    default_locations_text = "all health-regions independently",
-                                    reference_date="2021_07_05",
-                                    aggregate_name="SC_ESTADO",
-                                    nickname="RSA")
-    
-    opt_parser <- OptionParser(option_list=option_list);
-    opt <- parse_args(opt_parser);
-    
-    
-    # TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
-    model_output <- run_model_with_opt(opt,opt[["allowed_locations"]])
-    if (i == 1){
-        model_files <- copy(model_output$filename_suffix)
-    } else {
-        model_files <- append(model_files, model_output$filename_suffix )
-    }
-    rm(model_output)    
-
+for (location in micro_health_regions_A){
+  
+  i <- which(micro_health_regions_A == location)
+  option_list <- make_option_list(location,
+                                  mode="FULL",
+                                  default_locations_text = "all health-regions independently",
+                                  reference_date="2021_07_05",
+                                  aggregate_name="SC_ESTADO",
+                                  nickname="RSA")
+  
+  opt_parser <- OptionParser(option_list=option_list);
+  opt <- parse_args(opt_parser);
+  
+  w <- strsplit(location, "_")
+  short_name <- w[[1]][3:length((w[[1]]))]
+  location_nickname <- paste(short_name, collapse = '_')
+  
+  i <- which(micro_health_regions_A == location)
+  
+  if (!is.null(opt$model_init_filename)) {
+    last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - 7, "%Y_%m_%d")
+    dir_last_model <- paste0("../results/", last_model_date)
+    glob_var <- paste0("*", location_nickname, "*")
+    model_init_fname <- fs::dir_ls(path = dir_last_model, type = "file", glob = glob_var)
+  } else {
+    model_init_fname <- NULL
+  }
+  
+  opt$model_init_filename <- model_init_fname
+  opt$allowed_locations <- location
+  
+  # TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
+  model_output <- run_model_with_opt_independent(opt,opt[["allowed_locations"]])
+  if (i == 1){
+    model_files <- copy(model_output$filename_suffix)
+  } else {
+    model_files <- append(model_files, model_output$filename_suffix )
+  }
+  rm(model_output)
+  
 }
-

--- a/run_health_regions_B.R
+++ b/run_health_regions_B.R
@@ -15,13 +15,13 @@ macro_health_regions <- c("SC_MAC_FOZ_DO_RIO_ITAJAI",
                           "SC_MAC_MEIO_OESTE_E_SERRA_CATARINENSE")
 
 micro_health_regions_A <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
-                          "SC_RSA_ALTO_VALE_DO_ITAJAI",
-                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
-                          "SC_RSA_CARBONIFERA",
-                          "SC_RSA_EXTREMO_OESTE",
-                          "SC_RSA_EXTREMO_SUL_CATARINENSE",
-                          "SC_RSA_FOZ_DO_RIO_ITAJAI",
-                          "SC_RSA_GRANDE_FLORIANOPOLIS")
+                            "SC_RSA_ALTO_VALE_DO_ITAJAI",
+                            "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
+                            "SC_RSA_CARBONIFERA",
+                            "SC_RSA_EXTREMO_OESTE",
+                            "SC_RSA_EXTREMO_SUL_CATARINENSE",
+                            "SC_RSA_FOZ_DO_RIO_ITAJAI",
+                            "SC_RSA_GRANDE_FLORIANOPOLIS")
 
 
 micro_health_regions_B <- c("SC_RSA_LAGUNA",
@@ -35,28 +35,46 @@ micro_health_regions_B <- c("SC_RSA_LAGUNA",
 
 micro_health_regions <- c(micro_health_regions_A, micro_health_regions_B)
 
-for (location in micro_health_regions_B){ 
-    i <- which(micro_health_regions_B==location)
-    option_list <- make_option_list(location,
-                                    mode="FULL",
-                                    default_locations_text = "health-regions B",
-                                    reference_date="2021_07_05",
-                                    aggregate_name="SC_ESTADO",
-                                    nickname="RSA")
-    
-    opt_parser <- OptionParser(option_list=option_list);
-    opt <- parse_args(opt_parser);
-    
-    
-    # TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
-    model_output <- run_model_with_opt(opt,opt[["allowed_locations"]])
-    if (i == 1){
-        model_files <- copy(model_output$filename_suffix)
-    } else {
-        model_files <- append(model_files, model_output$filename_suffix )
-    }
-    rm(model_output)    
-
+for (location in micro_health_regions_B){
+  i <- which(micro_health_regions_B == location)
+  option_list <- make_option_list(location,
+                                  mode="FULL",
+                                  default_locations_text = "all health-regions independently",
+                                  reference_date="2021_07_05",
+                                  aggregate_name="SC_ESTADO",
+                                  nickname="RSA")
+  
+  opt_parser <- OptionParser(option_list=option_list);
+  opt <- parse_args(opt_parser);
+  
+  
+  w <- strsplit(location, "_")
+  short_name <- w[[1]][3:length((w[[1]]))]
+  location_nickname <- paste(short_name, collapse = '_')
+  
+  i <- which(micro_health_regions_B == location)
+  
+  if (!is.null(opt$model_init_filename)) {
+    last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - 7, "%Y_%m_%d")
+    dir_last_model <- paste0("../results/", last_model_date)
+    glob_var <- paste0("*", location_nickname, "*")
+    model_init_fname <- fs::dir_ls(path = dir_last_model, type = "file", glob = glob_var)
+  } else {
+    model_init_fname <- NULL
+  }
+  
+  opt$model_init_filename <- model_init_fname
+  opt$allowed_locations <- location
+  
+  # TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
+  model_output <- run_model_with_opt_independent(opt,opt[["allowed_locations"]])
+  if (i == 1){
+    model_files <- copy(model_output$filename_suffix)
+  } else {
+    model_files <- append(model_files, model_output$filename_suffix )
+  }
+  rm(model_output)
+  
 }
 
 

--- a/run_health_regions_independently.R
+++ b/run_health_regions_independently.R
@@ -32,7 +32,6 @@ micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
                           "SC_RSA_SERRA_CATARINENSE",
                           "SC_RSA_XANXERE")
 
-
 option_list <- make_option_list(micro_health_regions,
                                 mode="FULL",
                                 default_locations_text = "all health-regions independently",

--- a/run_health_regions_independently.R
+++ b/run_health_regions_independently.R
@@ -32,9 +32,6 @@ micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
                           "SC_RSA_SERRA_CATARINENSE",
                           "SC_RSA_XANXERE")
 
-micro_health_regions <- c("SC_RSA_XANXERE",
-                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE")
-
 
 option_list <- make_option_list(micro_health_regions,
                                 mode="DEBUG",
@@ -77,6 +74,11 @@ for (location in micro_health_regions){
 
 }
 
+# update covid_data in model_output_all
+covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
+                                  allowed_locations = micro_health_regions
+)
+
 dir_saved_models <- paste0(opt$save_path,"results/", strftime(opt$reference_date, "%Y_%m_%d") )
 this_dir = getwd()
 
@@ -102,22 +104,22 @@ if (length(model_files) != length(micro_health_regions)){
     }
 }
 
-model_output_all_filename <- paste0(model_output_all$reference_date_str, "_",
-                          model_output_all$model_name,
-                          "_", model_output_all$mode,
-                          "_HEALTH-REG-INDEPEND-stanfit.Rdata")
+model_output_all[["covid_data"]] <- covid_data_all
+
+filename_suffix <- paste0(model_output_all$reference_date_str, "_",
+                          model_output_all$model_name, "_",
+                          model_output_all$mode, "_",
+                          "HEALTH-REG-INDEPEND")
+
+model_output_all$filename_suffix <- filename_suffix
+
+model_output_all_filename <- paste0(model_output_all$filename_suffix, "-stanfit.Rdata")
 
 cat(sprintf("\nSaving joint model objects to %s", model_output_all_filename))
 save(model_output_all, file = model_output_all_filename)
 
 setwd(this_dir)
 
-# update covid_data in model_output_all
-covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
-                              allowed_locations = micro_health_regions
-)
-
-model_output_all[["covid_data"]] <- covid_data_all
 
 make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name,
                           save_path = opt$save_path)

--- a/run_health_regions_independently.R
+++ b/run_health_regions_independently.R
@@ -34,7 +34,7 @@ micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
 
 
 option_list <- make_option_list(micro_health_regions,
-                                mode="DEBUG",
+                                mode="FULL",
                                 default_locations_text = "all health-regions independently",
                                 reference_date="2020_07_10",
                                 aggregate_name="SC_ESTADO",

--- a/run_health_regions_independently.R
+++ b/run_health_regions_independently.R
@@ -16,21 +16,8 @@ macro_health_regions <- c("SC_MAC_FOZ_DO_RIO_ITAJAI",
                           "SC_MAC_MEIO_OESTE_E_SERRA_CATARINENSE")
 
 micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
-                          "SC_RSA_ALTO_VALE_DO_ITAJAI",
-                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
-                          "SC_RSA_CARBONIFERA",
-                          "SC_RSA_EXTREMO_OESTE",
-                          "SC_RSA_EXTREMO_SUL_CATARINENSE",
-                          "SC_RSA_FOZ_DO_RIO_ITAJAI",
-                          "SC_RSA_GRANDE_FLORIANOPOLIS",
-                          "SC_RSA_LAGUNA",
-                          "SC_RSA_MEDIO_VALE_DO_ITAJAI",
-                          "SC_RSA_MEIO_OESTE",
-                          "SC_RSA_NORDESTE",
-                          "SC_RSA_OESTE",
-                          "SC_RSA_PLANALTO_NORTE",
-                          "SC_RSA_SERRA_CATARINENSE",
-                          "SC_RSA_XANXERE")
+                          "SC_RSA_ALTO_VALE_DO_ITAJAI")
+
 
 option_list <- make_option_list(micro_health_regions,
                                 mode="FULL",
@@ -44,7 +31,7 @@ opt <- parse_args(opt_parser);
 
 
 for (location in micro_health_regions){
-    w<-strsplit(location, "_")
+    w <- strsplit(location, "_")
     short_name <- w[[1]][3:length((w[[1]]))]
     location_nickname <-paste(short_name, collapse = '_')
     
@@ -53,7 +40,7 @@ for (location in micro_health_regions){
     if (!is.null(opt$model_init_filename)) {
         last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - 7, "%Y_%m_%d")
         dir_last_model <- paste0("../results/", last_model_date)
-        glob_var<-paste0("*", location_nickname, "*")
+        glob_var <- paste0("*", location_nickname, "*")
         model_init_fname <- fs::dir_ls(path = dir_last_model, type = "file", glob = glob_var)
     } else {
         model_init_fname <- NULL

--- a/run_health_regions_independently.R
+++ b/run_health_regions_independently.R
@@ -4,6 +4,7 @@ library(epiCata)
 library(lubridate)
 library(data.table)
 library(abind)
+library(optparse)
 
 
 macro_health_regions <- c("SC_MAC_FOZ_DO_RIO_ITAJAI",
@@ -31,28 +32,48 @@ micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
                           "SC_RSA_SERRA_CATARINENSE",
                           "SC_RSA_XANXERE")
 
+micro_health_regions <- c("SC_RSA_XANXERE",
+                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE")
 
-for (location in micro_health_regions){ 
+
+option_list <- make_option_list(micro_health_regions,
+                                mode="DEBUG",
+                                default_locations_text = "all health-regions independently",
+                                reference_date="2020_07_10",
+                                aggregate_name="SC_ESTADO",
+                                nickname="RSA")
+
+opt_parser <- OptionParser(option_list=option_list);
+opt <- parse_args(opt_parser);
+
+
+for (location in micro_health_regions){
+    w<-strsplit(location, "_")
+    short_name <- w[[1]][3:length((w[[1]]))]
+    location_nickname <-paste(short_name, collapse = '_')
+    
     i <- which(micro_health_regions==location)
-    option_list <- make_option_list(location,
-                                    mode="FULL",
-                                    default_locations_text = "all health-regions independently",
-                                    reference_date="2021_07_05",
-                                    aggregate_name="SC_ESTADO",
-                                    nickname="RSA")
     
-    opt_parser <- OptionParser(option_list=option_list);
-    opt <- parse_args(opt_parser);
+    if (!is.null(opt$model_init_filename)) {
+        last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - 7, "%Y_%m_%d")
+        dir_last_model <- paste0("../results/", last_model_date)
+        glob_var<-paste0("*", location_nickname, "*")
+        model_init_fname <- fs::dir_ls(path = dir_last_model, type = "file", glob = glob_var)
+    } else {
+        model_init_fname <- NULL
+    }
     
-    
+    opt$model_init_filename <- model_init_fname
+    opt$allowed_locations <- location
+
     # TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
-    model_output <- run_model_with_opt(opt,opt[["allowed_locations"]])
+    model_output <- run_model_with_opt_independent(opt,opt[["allowed_locations"]])
     if (i == 1){
         model_files <- copy(model_output$filename_suffix)
     } else {
         model_files <- append(model_files, model_output$filename_suffix )
     }
-    rm(model_output)    
+    rm(model_output)
 
 }
 
@@ -65,12 +86,12 @@ if (length(model_files) != length(micro_health_regions)){
     sprintf("Not enough single-region models! Check if all models concluded successfully. Expected %s, got %s",
                     length(micro_health_regions), length(model_files)    )
     # HOW DO I PRINT AN ERROR HERE?
-    
+
 } else {
-    for (model_file in model_files){ 
+    for (model_file in model_files){
         i <- which(model_files==model_file)
         load(paste0(model_file, "-stanfit.Rdata") )
-        
+
         if (i==1){
             model_output_all <- copy(model_output)
             model_output_all$stan_list$stan_data$M <- length(micro_health_regions)
@@ -81,7 +102,11 @@ if (length(model_files) != length(micro_health_regions)){
     }
 }
 
-model_output_all_filename <- paste0(model_output_all$filename_suffix, "-HEALTH-REG-INDEPEND-stanfit.Rdata")
+model_output_all_filename <- paste0(model_output_all$reference_date_str, "_",
+                          model_output_all$model_name,
+                          "_", model_output_all$mode,
+                          "_HEALTH-REG-INDEPEND-stanfit.Rdata")
+
 cat(sprintf("\nSaving joint model objects to %s", model_output_all_filename))
 save(model_output_all, file = model_output_all_filename)
 
@@ -89,20 +114,20 @@ setwd(this_dir)
 
 # update covid_data in model_output_all
 covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
-                              allowed_locations = micro_health_regions 
+                              allowed_locations = micro_health_regions
 )
 
 model_output_all[["covid_data"]] <- covid_data_all
 
-make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name, 
+make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name,
                           save_path = opt$save_path)
 
 mi <- NULL
 wma <- NULL
 ma <- NULL
 
-make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name, 
-                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma, 
+make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name,
+                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma,
                         save_path = opt$save_path)
 
 last_8_weeks = ymd(model_output_all$reference_date_str) - 8*7 - 1

--- a/run_macro_regions_independently.R
+++ b/run_macro_regions_independently.R
@@ -3,6 +3,8 @@ library(epiCataPlot)
 library(epiCata)
 library(lubridate)
 library(data.table)
+library(abind)
+library(optparse)
 
 
 macro_health_regions <- c("SC_MAC_FOZ_DO_RIO_ITAJAI",
@@ -31,29 +33,51 @@ micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
                           "SC_RSA_XANXERE")
 
 
-for (location in macro_health_regions){ 
+option_list <- make_option_list(macro_health_regions,
+                                mode="DEBUG",
+                                default_locations_text = "all health-regions independently",
+                                reference_date="2020_07_10",
+                                aggregate_name="SC_ESTADO",
+                                nickname="RSA")
+
+opt_parser <- OptionParser(option_list=option_list);
+opt <- parse_args(opt_parser);
+
+
+for (location in macro_health_regions){
+    w<-strsplit(location, "_")
+    short_name <- w[[1]][3:length((w[[1]]))]
+    location_nickname <-paste(short_name, collapse = '_')
+    
     i <- which(macro_health_regions==location)
-    option_list <- make_option_list(location,
-                                    mode="FULL",
-                                    default_locations_text = "all macro-regions independently",
-                                    reference_date="2021_07_05",
-                                    aggregate_name="SC_ESTADO",
-                                    nickname="MAC")
     
-    opt_parser <- OptionParser(option_list=option_list);
-    opt <- parse_args(opt_parser);
+    if (!is.null(opt$model_init_filename)) {
+        last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - 7, "%Y_%m_%d")
+        dir_last_model <- paste0("../results/", last_model_date)
+        glob_var<-paste0("*", location_nickname, "*")
+        model_init_fname <- fs::dir_ls(path = dir_last_model, type = "file", glob = glob_var)
+    } else {
+        model_init_fname <- NULL
+    }
     
+    opt$model_init_filename <- model_init_fname
+    opt$allowed_locations <- location
     
     # TODO: allowed_locations is a misnomer. Rename it to "selected_locations" so it makes more sense.
-    model_output <- run_model_with_opt(opt,opt[["allowed_locations"]])
+    model_output <- run_model_with_opt_independent(opt,opt[["allowed_locations"]])
     if (i == 1){
         model_files <- copy(model_output$filename_suffix)
     } else {
         model_files <- append(model_files, model_output$filename_suffix )
     }
-    rm(model_output)    
-
+    rm(model_output)
+    
 }
+
+# update covid_data in model_output_all
+covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
+                                  allowed_locations = macro_health_regions
+)
 
 dir_saved_models <- paste0(opt$save_path,"results/", strftime(opt$reference_date, "%Y_%m_%d") )
 this_dir = getwd()
@@ -62,11 +86,11 @@ setwd(dir_saved_models)
 
 if (length(model_files) != length(macro_health_regions)){
     sprintf("Not enough single-region models! Check if all models concluded successfully. Expected %s, got %s",
-                    length(macro_health_regions), length(model_files)    )
+            length(macro_health_regions), length(model_files)    )
     # HOW DO I PRINT AN ERROR HERE?
     
 } else {
-    for (model_file in model_files){ 
+    for (model_file in model_files){
         i <- which(model_files==model_file)
         load(paste0(model_file, "-stanfit.Rdata") )
         
@@ -80,28 +104,32 @@ if (length(model_files) != length(macro_health_regions)){
     }
 }
 
-model_output_all_filename <- paste0(model_output_all$filename_suffix, "-MACRO-REG-INDEPEND-stanfit.Rdata")
+model_output_all[["covid_data"]] <- covid_data_all
+
+filename_suffix <- paste0(model_output_all$reference_date_str, "_",
+                          model_output_all$model_name, "_",
+                          model_output_all$mode, "_",
+                          "MACRO-REG-INDEPEND")
+
+model_output_all$filename_suffix <- filename_suffix
+
+model_output_all_filename <- paste0(model_output_all$filename_suffix, "-stanfit.Rdata")
+
 cat(sprintf("\nSaving joint model objects to %s", model_output_all_filename))
 save(model_output_all, file = model_output_all_filename)
 
 setwd(this_dir)
 
-# update covid_data in model_output_all
-covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
-                              allowed_locations = macro_health_regions 
-)
 
-model_output_all[["covid_data"]] <- covid_data_all
-
-make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name, 
+make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name,
                           save_path = opt$save_path)
 
 mi <- NULL
 wma <- NULL
 ma <- NULL
 
-make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name, 
-                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma, 
+make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name,
+                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma,
                         save_path = opt$save_path)
 
 last_8_weeks = ymd(model_output_all$reference_date_str) - 8*7 - 1

--- a/run_macro_regions_independently.R
+++ b/run_macro_regions_independently.R
@@ -34,11 +34,11 @@ micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
 
 
 option_list <- make_option_list(macro_health_regions,
-                                mode="DEBUG",
-                                default_locations_text = "all health-regions independently",
+                                mode="FULL",
+                                default_locations_text = "all macro-regions independently",
                                 reference_date="2020_07_10",
                                 aggregate_name="SC_ESTADO",
-                                nickname="RSA")
+                                nickname="MAC")
 
 opt_parser <- OptionParser(option_list=option_list);
 opt <- parse_args(opt_parser);

--- a/run_macro_regions_independently.R
+++ b/run_macro_regions_independently.R
@@ -52,7 +52,8 @@ for (location in macro_health_regions){
     i <- which(macro_health_regions==location)
     
     if (!is.null(opt$model_init_filename)) {
-        last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - 7, "%Y_%m_%d")
+        last_model_date <- strftime(as.Date(opt$reference_date, "%Y-%m-%d") - opt$model_init_period_dif,
+                                    "%Y_%m_%d")
         dir_last_model <- paste0("../results/", last_model_date)
         glob_var<-paste0("*", location_nickname, "*")
         model_init_fname <- fs::dir_ls(path = dir_last_model, type = "file", glob = glob_var)


### PR DESCRIPTION
## Changes

* Now it is possible to use ` run_health_regions_independently.R` and `run_macro_regions_independently.R` with previously trained models for  each independent region. As before, when the option `-e` is not called, no pre-trained model will be used. Call `-e True` (or `-e` followed by any string) to associate the model trained **before** for each single region.
* Option **-j**: number of days the input model is distant from the current date. I.e., if you use an initial model as "start" from 2 weeks ago, use **`-j 14`**; Default = 7 days. 
* All single region files now contain the region description within the filename
* It works both with "base" and "base_reported"
## Bugfix 
* Saved complete model now contains data from all single regions within `model_output_all$covid_data`

## Validating
1. First, one must train the previous week models:
`Rscript run_health_regions_independently.R  -u "base" -r "2021-06-28"`

2. Then, run the same code considering also the next **7** days:
`Rscript run_health_regions_independently.R  -u "base" -r "2021-07-05" -e True -j 7`
The `-j 7` is optional in this case, since 7 is the default value.
