### PR TITLE
⚙️ Split microregions in two scripts so they can be run in parallel

### DIFF
--- a/combine_independent_results.R
+++ b/combine_independent_results.R
@@ -1,0 +1,107 @@
+library(optparse)
+library(epiCataPlot)
+library(epiCata)
+library(lubridate)
+library(data.table)
+library(abind)
+
+
+macro_health_regions <- c("SC_MAC_FOZ_DO_RIO_ITAJAI",
+                          "SC_MAC_PLANALTO_NORTE_E_NORDESTE",
+                          "SC_MAC_GRANDE_OESTE",
+                          "SC_MAC_GRANDE_FLORIANOPOLIS",
+                          "SC_MAC_SUL",
+                          "SC_MAC_ALTO_VALE_DO_ITAJAI",
+                          "SC_MAC_MEIO_OESTE_E_SERRA_CATARINENSE")
+
+micro_health_regions <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
+                          "SC_RSA_ALTO_VALE_DO_ITAJAI",
+                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
+                          "SC_RSA_CARBONIFERA",
+                          "SC_RSA_EXTREMO_OESTE",
+                          "SC_RSA_EXTREMO_SUL_CATARINENSE",
+                          "SC_RSA_FOZ_DO_RIO_ITAJAI",
+                          "SC_RSA_GRANDE_FLORIANOPOLIS",
+                          "SC_RSA_LAGUNA",
+                          "SC_RSA_MEDIO_VALE_DO_ITAJAI",
+                          "SC_RSA_MEIO_OESTE",
+                          "SC_RSA_NORDESTE",
+                          "SC_RSA_OESTE",
+                          "SC_RSA_PLANALTO_NORTE",
+                          "SC_RSA_SERRA_CATARINENSE",
+                          "SC_RSA_XANXERE")
+
+
+option_list <- make_option_list(micro_health_regions,
+                                    mode="FULL",
+                                    default_locations_text = "all health-regions independently",
+                                    reference_date="2021_07_05",
+                                    aggregate_name="SC_ESTADO",
+                                    nickname="RSA")
+    
+opt_parser <- OptionParser(option_list=option_list);
+opt <- parse_args(opt_parser);
+    
+
+dir_saved_models <- paste0(opt$save_path,"results/", strftime(opt$reference_date, "%Y_%m_%d") )
+model_files <- list.files(dir_saved_models)
+
+this_dir = getwd()
+
+setwd(dir_saved_models)
+
+if (length(model_files) != length(micro_health_regions)){
+    print(sprintf("Not enough single-region models! Check if all models concluded successfully. Expected %s, got %s",
+                    length(micro_health_regions), length(model_files)))
+    
+} else {
+    for (model_file in model_files){ 
+        i <- which(model_files==model_file)
+        print(sprint("Loading %s", model_file))
+	load(model_file)
+       
+        if (i==1){
+            model_output_all <- copy(model_output)
+            model_output_all$stan_list$stan_data$M <- length(micro_health_regions)
+        } else {
+            model_output_all <- update_aggregated_model(model_output_all, model_output)
+        }
+        rm(model_output)
+    }
+}
+
+model_output_all_filename <- paste0(model_output_all$filename_suffix, "-HEALTH-REG-INDEPEND-stanfit.Rdata")
+cat(sprintf("\nSaving joint model objects to %s", model_output_all_filename))
+save(model_output_all, file = model_output_all_filename)
+
+
+setwd(this_dir)
+
+# update covid_data in model_output_all
+covid_data_all <- read_covid_data(opt[["deaths"]], opt[["population"]], opt[["reference_date"]],
+                              allowed_locations = micro_health_regions 
+)
+
+model_output_all[["covid_data"]] <- covid_data_all
+
+
+make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name, save_path = opt$save_path)
+
+mi <- NULL
+wma <- NULL
+ma <- NULL
+
+make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name, 
+                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma, 
+                        save_path = opt$save_path)
+
+last_8_weeks = ymd(model_output_all$reference_date_str) - 8*7 - 1
+
+make_all_C_plot(model_output_all, aggregate_name = opt$aggregate_name, min_x_break=last_8_weeks, save_path = opt$save_path)
+
+save_data_for_dashboard(model_output_all, save_path = "~/epiCataDashboard/", aggregate_name = opt$aggregate_name)
+
+print("Done")
+
+
+

--- a/run_health_regions_A.R
+++ b/run_health_regions_A.R
@@ -15,13 +15,13 @@ macro_health_regions <- c("SC_MAC_FOZ_DO_RIO_ITAJAI",
                           "SC_MAC_MEIO_OESTE_E_SERRA_CATARINENSE")
 
 micro_health_regions_A <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
-                          "SC_RSA_ALTO_VALE_DO_ITAJAI",
-                          "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
-                          "SC_RSA_CARBONIFERA",
-                          "SC_RSA_EXTREMO_OESTE",
-                          "SC_RSA_EXTREMO_SUL_CATARINENSE",
-                          "SC_RSA_FOZ_DO_RIO_ITAJAI",
-                          "SC_RSA_GRANDE_FLORIANOPOLIS")
+                            "SC_RSA_ALTO_VALE_DO_ITAJAI",
+                            "SC_RSA_ALTO_VALE_DO_RIO_DO_PEIXE",
+                            "SC_RSA_CARBONIFERA",
+                            "SC_RSA_EXTREMO_OESTE",
+                            "SC_RSA_EXTREMO_SUL_CATARINENSE",
+                            "SC_RSA_FOZ_DO_RIO_ITAJAI",
+                            "SC_RSA_GRANDE_FLORIANOPOLIS")
 
 
 

--- a/run_health_regions_B.R
+++ b/run_health_regions_B.R
@@ -24,15 +24,14 @@ micro_health_regions_A <- c("SC_RSA_ALTO_URUGUAI_CATARINENSE",
                           "SC_RSA_GRANDE_FLORIANOPOLIS")
 
 
-
 micro_health_regions_B <- c("SC_RSA_LAGUNA",
-                          "SC_RSA_MEDIO_VALE_DO_ITAJAI",
-                          "SC_RSA_MEIO_OESTE",
-                          "SC_RSA_NORDESTE",
-                          "SC_RSA_OESTE",
-                          "SC_RSA_PLANALTO_NORTE",
-                          "SC_RSA_SERRA_CATARINENSE",
-                          "SC_RSA_XANXERE")
+                            "SC_RSA_MEDIO_VALE_DO_ITAJAI",
+                            "SC_RSA_MEIO_OESTE",
+                            "SC_RSA_NORDESTE",
+                            "SC_RSA_OESTE",
+                            "SC_RSA_PLANALTO_NORTE",
+                            "SC_RSA_SERRA_CATARINENSE",
+                            "SC_RSA_XANXERE")
 
 micro_health_regions <- c(micro_health_regions_A, micro_health_regions_B)
 


### PR DESCRIPTION
Closes #44 

Splitting in two separate scripts means the machine will use 8 vCPUs at the same time since each stan inference is running under 4 chains. So, make sure to have that many CPUs available.

# How to validate this PR

1.  Open the terminal, run A script and run B script for the desired reference_date (typically that is monday). Example:

```console
nohup Rscript run_health_regions_A.R -u "base-reported" -m DEVELOP -k 7 -i 4000 -w 2000 -c 4 -t 9 -r "2021-07-19" > ../logs/health-regions-B-base-reported-2021-07-19-DEVELOP-4000-2000-4-9.out &
```
then
```console
nohup Rscript run_health_regions_B.R -u "base-reported" -m DEVELOP -k 7 -i 4000 -w 2000 -c 4 -t 9 -r "2021-07-19" > ../logs/health-regions-B-base-reported-2021-07-19-DEVELOP-4000-2000-4-9.out &
```

2. Monitor progress with `tail` or, prettier, with `multitail` command. Example:

```console
multitail -c /home/Jonathan/logs/health-regions-A-base-reported-2021-07-19-DEVELOP-4000-2000-4-9.out

multitail -c /home/Jonathan/logs/health-regions-B-base-reported-2021-07-19-DEVELOP-4000-2000-4-9.out
```

3. Once both scripts have completed, combine the results:

```console
 Rscript combine_independent_results.R -u "base-reported" -m DEVELOP -k 7 -i 4000 -w 2000 -c 4 -t 9 -r "2021-07-19"
```

Use the same parameters just to make sure names and dates are properly referenced.

4. Generate plots for the weekly report:

```r
cd epiCataDashboard/dashboard_results/
vim plot_report.R
R -f plot_report.R
```