### PR TITLE
Revise cases likelihood

### DIFF
--- a/combine_independent_results.R
+++ b/combine_independent_results.R
@@ -94,20 +94,20 @@ save(model_output_all, file = model_output_all_filename)
 setwd(this_dir)
 
 
-make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name,
-                          save_path = opt$save_path)
+#make_all_three_panel_plot(model_output_all, aggregate_name = opt$aggregate_name,
+#                          save_path = opt$save_path)
 
 mi <- NULL
 wma <- NULL
 ma <- NULL
 
-make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name,
-                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma,
-                        save_path = opt$save_path)
+#make_all_forecast_plots(model_output_all, aggregate_name = opt$aggregate_name,
+#                        min_y_breaks=mi,max_y_breaks=ma, week_max_y_breaks=wma,
+#                        save_path = opt$save_path)
 
-last_8_weeks = ymd(model_output_all$reference_date_str) - 8*7 - 1
+#last_8_weeks = ymd(model_output_all$reference_date_str) - 8*7 - 1
 
-make_all_C_plot(model_output_all, aggregate_name = opt$aggregate_name, min_x_break=last_8_weeks, save_path = opt$save_path)
+#make_all_C_plot(model_output_all, aggregate_name = opt$aggregate_name, min_x_break=last_8_weeks, save_path = opt$save_path)
 
 save_data_for_dashboard(model_output_all, save_path = "~/epiCataDashboard/", aggregate_name = opt$aggregate_name)
 

--- a/epiCata/inst/extdata/stan-models/base-reported.stan
+++ b/epiCata/inst/extdata/stan-models/base-reported.stan
@@ -105,7 +105,7 @@ model {
   infection_overestimate ~ normal(2,2);
   
   for(m in 1:M){
-    cases[3:(N[m]+2), m] ~ neg_binomial_2(prediction[1:N[m], m] / infection_overestimate[m], phi2);
+    cases[1:N[m], m] ~ neg_binomial_2(prediction[1:N[m], m] / infection_overestimate[m], phi2);
     deaths[1:N[m], m] ~ neg_binomial_2(E_deaths[1:N[m], m], phi);
    }
 }

--- a/epiCata/inst/extdata/stan-models/base-reported.stan
+++ b/epiCata/inst/extdata/stan-models/base-reported.stan
@@ -33,6 +33,7 @@ parameters {
   real<lower=0> kappa;
   real<lower=0> y[M];
   real<lower=0> phi;
+  real<lower=0> phi2;
   real<lower=0> tau;
   real <lower=0> ifr_noise[M];
   real alpha[P];
@@ -40,7 +41,7 @@ parameters {
   real alpha_pop;
   real alpha1_pop[M];
   
-  real<lower=0> infection_overestimate[M];
+  real<lower=1> infection_overestimate[M];
 }
 
 transformed parameters {
@@ -91,6 +92,7 @@ model {
   }
   gamma ~ normal(0,.2);
   phi ~ normal(0,5);
+  phi2 ~ normal(0,5);
   kappa ~ normal(0,0.5);
   mu ~ normal(3.28, kappa); // citation: https://academic.oup.com/jtm/article/27/2/taaa021/5735319
   alpha ~ normal(0,0.5);
@@ -103,7 +105,7 @@ model {
   infection_overestimate ~ normal(2,2);
   
   for(m in 1:M){
-    cases[1:N[m], m] ~ neg_binomial_2(prediction[1:N[m], m] / infection_overestimate[m], phi);
+    cases[3:(N[m]+2), m] ~ neg_binomial_2(prediction[1:N[m], m] / infection_overestimate[m], phi2);
     deaths[1:N[m], m] ~ neg_binomial_2(E_deaths[1:N[m], m], phi);
    }
 }

--- a/epiCata/inst/extdata/stan-models/base-reported.stan
+++ b/epiCata/inst/extdata/stan-models/base-reported.stan
@@ -105,7 +105,7 @@ model {
   infection_overestimate ~ normal(2,2);
   
   for(m in 1:M){
-    cases[1:N[m], m] ~ neg_binomial_2(prediction[1:N[m], m] / infection_overestimate[m], phi2);
+    cases[1:N[m], m] ~ neg_binomial_2(prediction[1:N[m], m] * infection_overestimate[m], phi2);
     deaths[1:N[m], m] ~ neg_binomial_2(E_deaths[1:N[m], m], phi);
    }
 }


### PR DESCRIPTION
# What this PR does

- Introduce a variable `phi2` to model the scale of the cases likelihood independently of the deaths likelihood
- Set `infection_overestimate` lower bound to 1, the intuition being that the number of estimated cases should be _at least_ the number of reported cases
- Comment figure saving parts of the code in script **combine_independent_results.R**. --> This does not change the [steps required to reproduce the weekly model](https://github.com/Data-Science-Brigade/modelo-epidemiologico-sc#how-to-run-the-model)


Closes #47 
Closes #56 (by simply commenting the parts of the code where figures are saved)